### PR TITLE
py-coverage-highlight.vim: fix typo: s/Higlight/Highlight/

### DIFF
--- a/plugin/py-coverage-highlight.vim
+++ b/plugin/py-coverage-highlight.vim
@@ -14,8 +14,8 @@
 " Usage with Ned Batchelder's coverage.py
 " ---------------------------------------
 " Produce a coverage report with coverage (it's assumed that either it's in
-" $PATH, or in $PWD/bin/coverage).  Open a source file.  Use :HiglightCoverage
-" to load coverage info, and :HiglightCoverageOff to turn it off.
+" $PATH, or in $PWD/bin/coverage).  Open a source file.  Use :HighlightCoverage
+" to load coverage info, and :HighlightCoverageOff to turn it off.
 "
 " You can also provide the missing lines directly on the command line,
 " eg. :HighlightCoverage NN-NN,NN-NN,NN-NN
@@ -29,14 +29,14 @@
 " Usage with Python's trace.py
 " ----------------------------
 " Produce a coverage report with Python's trace.py.  Open a source file.
-" Load the highlighting with :HiglightCoverage filename/to/coverage.report
-" Turn off the highlighting with :HiglightCoverageOff.
+" Load the highlighting with :HighlightCoverage filename/to/coverage.report
+" Turn off the highlighting with :HighlightCoverageOff.
 "
 " Usage with zope.testrunner
 " --------------------------
 " Produce a coverage report with bin/test --coverage=coverage.  Open a source
-" file.  Use :HiglightCoverage to load coverage info, and :HiglightCoverageOff
-" to turn it off.
+" file.  Use :HighlightCoverage to load coverage info, and
+" :HighlightCoverageOff to turn it off.
 "
 " zope.testrunner uses trace.py behind the scenes, and this plugin looks for
 " the reports in ./coverage or ./parts/test/working-directory/coverage and
@@ -56,7 +56,7 @@ if &t_Co > 8
 endif
 sign define NoCoverage text=>> texthl=NoCoverage linehl=NoCoverage
 
-function! HiglightCoverage(arg)
+function! HighlightCoverage(arg)
     sign unplace *
     let python = has('python3') ? 'python3' : 'python'
     exec python "<<END"
@@ -264,5 +264,5 @@ else:
 END
 endf
 
-command! -nargs=* -complete=file -bar HiglightCoverage	call HiglightCoverage(<q-args>)
-command!                         -bar HiglightCoverageOff	sign unplace *
+command! -nargs=* -complete=file -bar HighlightCoverage	call HighlightCoverage(<q-args>)
+command!                         -bar HighlightCoverageOff	sign unplace *


### PR DESCRIPTION
I am looking at plugins to display (missing) coverage in Vim from coverage.py, and came across yours.  Thanks for providing it!

btw: it also unplaces all signs unconditionally, but should only unplace its own (similar issue: https://github.com/alfredodeza/coveragepy.vim/issues/18).